### PR TITLE
:sparkles: Add new require js import rule

### DIFF
--- a/packages/ts/lib/index.ts
+++ b/packages/ts/lib/index.ts
@@ -4,6 +4,7 @@
  */
 
 import noRelativeImports from "./rules/no-relative-imports"
+import requireImportJsExtension from "./rules/require-import-js-extension"
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
@@ -15,6 +16,7 @@ import noRelativeImports from "./rules/no-relative-imports"
 
 export const rules = {
     "no-relative-imports": noRelativeImports,
+    "require-import-js-extension": requireImportJsExtension,
 }
 
 export const configs = {

--- a/packages/ts/lib/rules/require-import-js-extension.ts
+++ b/packages/ts/lib/rules/require-import-js-extension.ts
@@ -42,7 +42,7 @@ export default creator<Options, MessageIds>({
             ImportDeclaration(node) {
                 const source = node.source.value
 
-                if (source.indexOf(".") !== -1) {
+                if (possibleExtensions.some((it) => source.endsWith(it))) {
                     return
                 }
 

--- a/packages/ts/lib/rules/require-import-js-extension.ts
+++ b/packages/ts/lib/rules/require-import-js-extension.ts
@@ -55,6 +55,10 @@ export default creator<Options, MessageIds>({
                     context
                 )
 
+                if (!directFileExist && !indexFileExist) {
+                    return
+                }
+
                 context.report({
                     node,
                     messageId: "require-import-js-extension",

--- a/packages/ts/lib/rules/require-import-js-extension.ts
+++ b/packages/ts/lib/rules/require-import-js-extension.ts
@@ -42,6 +42,11 @@ export default creator<Options, MessageIds>({
             ImportDeclaration(node) {
                 const source = node.source.value
 
+                // only work on relative imports otherwise packages that have the same name as a file will break this
+                if (!source.startsWith(".")) {
+                   return
+                }
+
                 if (possibleExtensions.some((it) => source.endsWith(it))) {
                     return
                 }

--- a/packages/ts/lib/rules/require-import-js-extension.ts
+++ b/packages/ts/lib/rules/require-import-js-extension.ts
@@ -66,14 +66,14 @@ export default creator<Options, MessageIds>({
                         if (directFileExist) {
                             return fixer.replaceText(
                                 node.source,
-                                `${source}.js`
+                                `"${source}.js"`
                             )
                         }
 
                         if (indexFileExist) {
                             return fixer.replaceText(
                                 node.source,
-                                `${source}/index.js`
+                                `"${source}/index.js"`
                             )
                         }
 

--- a/packages/ts/lib/rules/require-import-js-extension.ts
+++ b/packages/ts/lib/rules/require-import-js-extension.ts
@@ -1,0 +1,72 @@
+import { ESLintUtils } from "@typescript-eslint/utils"
+import path from "path"
+import fs from "fs"
+
+const { RuleCreator } = ESLintUtils
+const creator = RuleCreator((rule) => rule)
+
+export type Options = Record<never, never>[]
+
+export type MessageIds = "require-import-js-extension"
+export default creator<Options, MessageIds>({
+    name: "require-import-js-extension",
+    meta: {
+        type: "problem",
+        docs: {
+            description: "Requires using .js extension for imports",
+            recommended: "error",
+        },
+        fixable: "code",
+        messages: {
+            "require-import-js-extension": "No relative imports",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        return {
+            ImportDeclaration(node) {
+                const source = node.source.value
+
+                if (source.indexOf(".") === -1) {
+                    return
+                }
+
+                const directFileExist = fs.existsSync(
+                    path.resolve(
+                        path.dirname(context.getFilename()),
+                        source + ".js"
+                    )
+                )
+                const indexFileExist = fs.existsSync(
+                    path.resolve(
+                        path.dirname(context.getFilename()),
+                        source + "/index.js"
+                    )
+                )
+
+                context.report({
+                    node,
+                    messageId: "require-import-js-extension",
+                    fix: function (fixer) {
+                        if (directFileExist) {
+                            return fixer.replaceText(
+                                node.source,
+                                `${source}.js`
+                            )
+                        }
+
+                        if (indexFileExist) {
+                            return fixer.replaceText(
+                                node.source,
+                                `${source}/index.js`
+                            )
+                        }
+
+                        return null
+                    },
+                })
+            },
+        }
+    },
+})


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/eslint-plugin-storybook@0.5.0-canary.20.5942690531.0
  npm install @opencreek/eslint-plugin-ts@0.5.0-canary.20.5942690531.0
  # or 
  yarn add @opencreek/eslint-plugin-storybook@0.5.0-canary.20.5942690531.0
  yarn add @opencreek/eslint-plugin-ts@0.5.0-canary.20.5942690531.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
